### PR TITLE
Feat/eslintconfig

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,10 +8,13 @@
 	},
 	"extends": "eslint:recommended",
 	"rules": {
-		"eqeqeq":     "error",
-		"strict":     "error",
-		"camelcase":  "error",
-		"func-names": ["error", "always"],
-		"quotes":     ["error", "single"]
+		"eqeqeq":       "error",
+		"strict":       "error",
+		"camelcase":    "error",
+		"comma-dangle": ["error", "never"],
+		"func-names":   ["error", "always"],
+		"quotes":       ["error", "single"],
+		"quote-props":  ["error", "as-needed"],
+		"yoda":         "error"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+	"parserOptions": {
+		"ecmaVersion":  6
+	},
+	"env": {
+		"browser": true,
+		"node":    true
+	},
+	"extends": "eslint:recommended",
+	"rules": {
+		"semi": 2
+	}
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,10 @@
 	},
 	"extends": "eslint:recommended",
 	"rules": {
-		"semi": 2
+		"eqeqeq":     "error",
+		"strict":     "error",
+		"camelcase":  "error",
+		"func-names": ["error", "always"],
+		"quotes":     ["error", "single"]
 	}
 }


### PR DESCRIPTION
Add a basic .eslintrc.json file that other projects can consume.

The only question is around: http://eslint.org/docs/rules/quotes

I've set it to single quotes at present however at some point i assume that we'll want to use the new ES6 backtick syntax in places. However we'll need to update the docs too when introducing that