### PR TITLE
fix: Alphabetically order the rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,13 +8,13 @@
 	},
 	"extends": "eslint:recommended",
 	"rules": {
-		"eqeqeq":       "error",
-		"strict":       "error",
 		"camelcase":    "error",
 		"comma-dangle": ["error", "never"],
+		"eqeqeq":       "error",
 		"func-names":   ["error", "always"],
 		"quotes":       ["error", "single"],
 		"quote-props":  ["error", "as-needed"],
+		"strict":       "error",
 		"yoda":         "error"
 	}
 }


### PR DESCRIPTION
Order the rules alphabetically to make finding them easier when we add more